### PR TITLE
[220131] NY

### DIFF
--- a/BOJ/Data_Structure/10799-쇠막대기-NY.py
+++ b/BOJ/Data_Structure/10799-쇠막대기-NY.py
@@ -1,0 +1,15 @@
+from sys import stdin
+brackets = str(stdin.readline().rstrip())
+
+temp_stack = []
+cnt = 0
+
+for i in range(len(brackets)):
+    if brackets[i] == '(':
+        temp_stack.append('(')
+    else: #bracket == ')'
+        temp_stack.pop()
+        if brackets[i-1] == '(': cnt += len(temp_stack)
+        else: cnt += 1
+        
+print(cnt)


### PR DESCRIPTION
이거 예전에도 겁나 못 풀어서 고생했는디.. 오늘도 마찬가지였다는..
원리는 입력받은 string을 한칸씩 움직이면서 만약 '('가 오면 스택에 더해주고 ')'가 오면 스택에서 pop해주는데

이때 ')' 바로 앞이 '('면 레이저인데 그럼 지금까지 스택에 더해준 '(' 값들이 다 겹쳐져 있는 막대기들이라서 무조건 다 잘리기 때문에
`cnt += len(temp_stack)`을 해주었습니다

그리고 만약 바로 앞이 '('가 아니면 ( '(())' 에서 마지막 괄호처럼)
막대기의 끝이고, 막대기의 끝이면 무조건 +1을 해주어야 하기 때문에 그 부분을 처리했습니다

https://www.acmicpc.net/source/38402296
시간은 96ms 걸렸네욥