### PR TITLE
[220225] NY

### DIFF
--- a/BOJ/Data_Structure/11286-절댓값_힙-NY.py
+++ b/BOJ/Data_Structure/11286-절댓값_힙-NY.py
@@ -1,0 +1,10 @@
+import heapq
+from sys import stdin
+N = int(stdin.readline())
+heap = []
+for _ in range(N):
+    cmd = int(stdin.readline())
+    if cmd: heapq.heappush(heap, [abs(cmd), cmd])
+    else:
+        if not heap: print(0)
+        else: print(heapq.heappop(heap)[1])


### PR DESCRIPTION
오늘은 저도 heapq 써서 풀었서요~
이틀전에 풀었던 최대 힙 문제랑 비슷하게 풀었는데용,
push할떄 [절댓값, 원래값] 이렇게 넣어줘서 마지막에 출력할때는 pop한 거의 [1]만 print했습니당

-1이랑 1 들어오면 절댓값은 1인데 원래값이 -1이 작아서 무조건 -1이 pop하면 먼저 나오게 됩니다

https://www.acmicpc.net/source/39590842

> 180ms