### PR TITLE
[220309] MH

### DIFF
--- a/BOJ/Data_Structure/21939-문제_추천_시스템_Version_1-MH.py
+++ b/BOJ/Data_Structure/21939-문제_추천_시스템_Version_1-MH.py
@@ -8,7 +8,7 @@ solved = {}                     # 문제가 풀렸으면 0, 풀리지 않았으�
 for i in range(int(stdin.readline())):
     P, L = map(int, stdin.readline().split())
     heappush(min_heap, (L, P))
-    heappush(max_heap, (-L, P))
+    heappush(max_heap, (-L, -P))
     solved[P] = L               # 현재 P의 L 저장
     
 for _ in range(int(stdin.readline())):
@@ -17,9 +17,9 @@ for _ in range(int(stdin.readline())):
     
     if cmd[0] == 'recommend':
         if cmd[1] == 1:
-            while solved[max_heap[0][1]] != -max_heap[0][0]:
+            while solved[-max_heap[0][1]] != -max_heap[0][0]:
                 heappop(max_heap)
-            print(max_heap[0][1])
+            print(-max_heap[0][1])
             
         elif cmd[1] == -1:
             while solved[min_heap[0][1]] != min_heap[0][0]:
@@ -29,22 +29,14 @@ for _ in range(int(stdin.readline())):
     elif cmd[0] == 'add':
         cmd[2] = int(cmd[2])
         
-        while solved[max_heap[0][1]] != -max_heap[0][0]:       # 같은 번호 다른 난이도 문제 방지
+        while solved[-max_heap[0][1]] != -max_heap[0][0]:       # 같은 번호 다른 난이도 문제 방지
             heappop(max_heap)
         while solved[min_heap[0][1]] != min_heap[0][0]:
             heappop(min_heap)
             
         heappush(min_heap, (cmd[2], cmd[1]))
-        heappush(max_heap, (-cmd[2], cmd[1]))
+        heappush(max_heap, (-cmd[2], -cmd[1]))
         solved[cmd[1]] = cmd[2]
     
     elif cmd[0] == 'solved':
         solved[cmd[1]] = 0      # 풀린 문제는 L을 0으로 설정
-                
-    # print('min heap : ', end='')
-    # print(min_heap)
-    # print('max heap : ', end='')
-    # print(max_heap)
-    # print('solved : ', end='')
-    # print(solved)
-    # print('---------')


### PR DESCRIPTION
드디어 패쓰!!!
바뀐 점..!! `solved[문제번호] = 문제가 풀린 여부(True or False)` 였는데
`solved[문제 번호] = 현재 풀리지 않은 문제의 레벨` 로 바꿨어요

원래 True False만 사용할 때는 2000 70이 들어오고 solved된 다음 2000 12가 들어오면 오류가 났습니댕

그래서 비교할 때는
`[heap에 있는 가장 쉬운 문제의 번호]를 인덱스로 찾은 solved에 저장된 현재 문제 레벨과 heap에 있는 가장 쉬운 문제 레벨 자체를 비교`해서 다르면 pop해줬어요
solved된 문제는 이제 True가 아닌 0으로 초기화 시켜줬습니다
그러면 우릴 괴롭혔던 반례 https://www.acmicpc.net/board/view/76245 해결!

그리고 heap에 입력할 때 문제 번호에도 마이너스 붙여줘서 같은 레벨의 문제가 있을 때 문제 번호 순으로 정렬했어용 히잉 문제 번호도 중요했꾸나

https://www.acmicpc.net/source/40184668
> 288ms